### PR TITLE
feat: client and server config streams for `rustls-config-stream`

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,5 @@
+[profile.ci]
+fail-fast = false
+
+[profile.ci.junit]
+path = "junit.xml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,11 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: spire/build
-          key: ${{ runner.os }}-spire
+          key: ${{ runner.os }}-spire-build
+      - uses: actions/cache@v4
+        with:
+          path: spire/bin
+          key: ${{ runner.os }}-spire-bin
       - uses: taiki-e/install-action@cargo-nextest
       - uses: taiki-e/install-action@cargo-llvm-cov
       - name: format

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         run: make up SHELL=/bin/bash
       - name: test
         run:
-          SPIFFE_ENDPOINT_SOCKET=unix:///tmp/spire-agent/public/api.sock \
+          SPIFFE_ENDPOINT_SOCKET=unix:///tmp/spire-agent/public/api.sock
           cargo llvm-cov nextest --profile ci
       - name: generate coverage report
         run: cargo llvm-cov report --codecov --output-path coverage.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,57 @@
+name: Tests
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  sonarqube:
+    name: SonarQube
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  test:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/cache@v4
+        with:
+          path: spire/build
+          key: ${{ runner.os }}-spire
+      - uses: taiki-e/install-action@cargo-nextest
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - name: format
+        run: cargo fmt --check
+      - name: lint
+        run: cargo clippy -- -D warnings
+      - name: build spire
+        run: make -C spire SHELL=/bin/bash
+      - name: start spire
+        run: make up SHELL=/bin/bash
+      - name: test
+        run:
+          SPIFFE_ENDPOINT_SOCKET=unix:///tmp/spire-agent/public/api.sock \
+          cargo llvm-cov nextest --profile ci
+      - name: generate coverage report
+        run: cargo llvm-cov report --codecov --output-path coverage.json
+      - name: upload codecov test report
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: upload codecov coverage report
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 /target
+Cargo.lock
+/spire/**
+!/spire/Makefile
+!/spire/conf
+!/spire/conf/*.conf

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,8 @@
+extends: default
+rules:
+  document-start: disable
+  brackets:
+    max-spaces-inside: 2
+  braces:
+    max-spaces-inside: 2
+  truthy: disable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-spiffe"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 description = "SPIFFE Integration with Rustls to provide Server and Client certs/keys and CA bundle"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,30 @@ name = "rustls-spiffe"
 version = "0.1.0"
 edition = "2024"
 description = "SPIFFE Integration with Rustls to provide Server and Client certs/keys and CA bundle"
-license = "MIT or Apache-2.0"
+license = "Apache-2.0 WITH LLVM-exception"
 
 [dependencies]
+rustls = { version = "0.23.31", default-features = false, features = [
+	"std",
+	"aws-lc-rs",
+] }
+rustls-config-stream = { version = "0.2.0", default-features = false, optional = true }
+spiffe = "0.6.7"
+tokio-stream = { version = "0.1.17", default-features = false, optional = true }
+tracing = { version = "0.1.41", default-features = false, optional = true }
+x509-parser = { version = "0.18.0", optional = true }
+
+[features]
+default = ["full"]
+full = ["config-stream", "svid-extractor", "tracing"]
+tracing = ["dep:tracing", "rustls-config-stream?/tracing"]
+config-stream = ["dep:rustls-config-stream", "dep:tokio-stream"]
+svid-extractor = ["dep:x509-parser"]
+
+[dev-dependencies]
+axum = "0.8.4"
+hyper = "1.7.0"
+hyper-util = "0.1.17"
+tokio = { version = "1.47.1", features = ["rt-multi-thread"] }
+tokio-rustls = "0.26.3"
+tower-service = "0.3.3"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,83 @@
+SPIRE_VERSION ?= 1.13.1
+SPIRE_DIR     ?= ./spire
+SERVER_BIN    ?= $(SPIRE_DIR)/bin/spire-server
+AGENT_BIN     ?= $(SPIRE_DIR)/bin/spire-agent
+CONFIG_DIR    ?= $(SPIRE_DIR)/conf
+AGENT_CONFIG  ?= $(CONFIG_DIR)/agent.conf
+SERVER_CONFIG ?= $(CONFIG_DIR)/server.conf
+LOG_DIR       ?= $(SPIRE_DIR)/log
+WORKLOAD_API  ?= $(TMPDIR)/spire-agent/public/api.sock
+SERVER_PID    := $(SPIRE_DIR)/server.pid
+AGENT_PID     := $(SPIRE_DIR)/agent.pid
+
+.PHONY: all deps clean up down test spire
+
+all: test
+
+deps: spire
+
+spire:
+	@$(MAKE) -C spire
+
+clean: down
+	@$(MAKE) -C spire clean
+	@rm -rf $(LOG_DIR)
+
+
+test: up
+	@export SPIFFE_ENDPOINT_SOCKET=unix://$(WORKLOAD_API) && \
+		cargo llvm-cov nextest --no-fail-fast || true
+	#$(MAKE) down
+
+up: $(AGENT_PID)
+
+$(SERVER_PID): spire
+	@[ -d $(LOG_DIR) ] || mkdir $(LOG_DIR)
+	@$(SERVER_BIN) run -expandEnv -config $(SERVER_CONFIG) > $(LOG_DIR)/server.log 2>&1 & \
+		echo $$! > $(SERVER_PID)
+	@# wait for server ready
+	@until curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/ready | grep -q 200; do \
+		echo "waiting for server..."; \
+		sleep 1; \
+	done
+	@$(SERVER_BIN) token generate \
+		-socketPath $(TMPDIR)/spire-server/private/api.sock \
+		-spiffeID spiffe://example.org/testagent \
+		> $(SPIRE_DIR)/join.token
+	@$(SERVER_BIN) entry create \
+		-socketPath $(TMPDIR)/spire-server/private/api.sock \
+		-selector "unix:uid:$$(id -u)" \
+		-parentID spiffe://example.org/testagent \
+		-spiffeID spiffe://example.org/testservice \
+		-dns localhost \
+		-dns 127.0.0.1
+	@echo "SPIRE server started."
+
+$(AGENT_PID): $(SERVER_PID)
+	@$(AGENT_BIN) run \
+		-insecureBootstrap \
+		-expandEnv \
+		-config $(AGENT_CONFIG) \
+		-joinToken $$(awk '{print $$2}' $(SPIRE_DIR)/join.token) \
+		> $(LOG_DIR)/agent.log 2>&1 & \
+		echo $$! > $(AGENT_PID)
+	@# wait for agent ready
+	@until curl -s -o /dev/null -w "%{http_code}" http://localhost:8082/ready | grep -q 200; do \
+		echo "waiting for server..."; \
+		sleep 1; \
+	done
+	@# wait for workload entry
+	@until $(AGENT_BIN) api fetch -socketPath $(WORKLOAD_API) | grep -q testservice; do \
+		echo "waiting for workload entry..."; \
+		sleep 1; \
+	done
+	@echo "SPIRE agent started."
+
+
+down:
+	@[ -f $(SPIRE_DIR)/agent.pid ] && kill $$(cat $(SPIRE_DIR)/agent.pid) || true
+	@[ -f $(SPIRE_DIR)/server.pid ] && kill $$(cat $(SPIRE_DIR)/server.pid) || true
+	@rm -f $(SPIRE_DIR)/*.pid $(SPIRE_DIR)/*.token
+	@rm -rf $(TMPDIR)/spire-server
+	@rm -rf $(TMPDIR)/spire-agent
+	@echo "SPIRE server and agent stopped."

--- a/README.tpl
+++ b/README.tpl
@@ -1,4 +1,4 @@
-# rustls-spiffe
+# {{crate}}
 
 [![crate](https://img.shields.io/crates/v/rustls-spiffe)](https://crates.io/crates/rustls-spiffe/)
 [![license](https://img.shields.io/crates/l/rustls-spiffe)](https://github.com/dsykes16/rustls-spiffe/blob/main/LICENSE)
@@ -11,10 +11,6 @@
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=dsykes16_rustls-spiffe&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=dsykes16_rustls-spiffe)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=dsykes16_rustls-spiffe&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=dsykes16_rustls-spiffe)
 
-Dynamic [`rustls`] TLS configuration backed by [`rustls-spiffe`] and [`rustls-config-stream`].
-Effortlessly hot-swap new X509-SVIDs and Trust Bundles
+{{readme}}
 
-Provides [`SpiffeClientConfigStream`] and [`SpiffeServerConfigStream`] for
-use with [`ClientConfigProvider`] and [`ServerConfigProvider`]
-
-License: Apache-2.0 WITH LLVM-exception
+License: {{license}}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,2 @@
+sonar.projectKey=dsykes16_rustls-spiffe
+sonar.organization=dsykes16

--- a/spire/Makefile
+++ b/spire/Makefile
@@ -4,6 +4,9 @@
 #   make clean
 #   make distclean
 
+SHELL := bash
+.SHELLFLAGS := -eu -o pipefail -c
+
 # ==== Configuration ====
 SPIRE_VERSION ?= 1.13.1
 TARBALL_URL   := https://github.com/spiffe/spire/archive/refs/tags/v$(SPIRE_VERSION).tar.gz
@@ -35,7 +38,6 @@ else
 endif
 
 # Make setup
-.SHELLFLAGS := -eu -o pipefail -c
 .ONESHELL:
 .DELETE_ON_ERROR:
 MAKEFLAGS += --no-builtin-rules

--- a/spire/Makefile
+++ b/spire/Makefile
@@ -1,0 +1,93 @@
+# Makefile for building spire-server and spire-agent from a versioned tarball.
+# Usage:
+#   make SPIRE_VERSION=1.11.2
+#   make clean
+#   make distclean
+
+# ==== Configuration ====
+SPIRE_VERSION ?= 1.13.1
+TARBALL_URL   := https://github.com/spiffe/spire/archive/refs/tags/v$(SPIRE_VERSION).tar.gz
+
+# Directories
+BUILD_DIR  := build
+BIN_DIR    := bin
+
+# Artifacts & stamps
+TARBALL        := $(BUILD_DIR)/spire-$(SPIRE_VERSION).tar.gz
+SRC_DIR        := $(BUILD_DIR)/spire-$(SPIRE_VERSION)
+EXTRACT_STAMP  := $(BUILD_DIR)/.extracted-spire-$(SPIRE_VERSION)
+VERSION_STAMP  := $(BIN_DIR)/.spire-version
+
+SERVER_BIN := $(BIN_DIR)/spire-server
+AGENT_BIN  := $(BIN_DIR)/spire-agent
+
+# Tools (prefer curl, fallback to wget)
+CURL := $(shell command -v curl 2>/dev/null)
+WGET := $(shell command -v wget 2>/dev/null)
+ifeq ($(CURL),)
+  ifeq ($(WGET),)
+    $(error Neither 'curl' nor 'wget' found in PATH)
+  else
+    DOWNLOADER = wget -O
+  endif
+else
+  DOWNLOADER = curl -fL -o
+endif
+
+# Make setup
+.SHELLFLAGS := -eu -o pipefail -c
+.ONESHELL:
+.DELETE_ON_ERROR:
+MAKEFLAGS += --no-builtin-rules
+.SUFFIXES:
+
+.PHONY: all clean distclean verify
+
+all: $(SERVER_BIN) $(AGENT_BIN)
+
+# Record the requested version; only update timestamp if content changes.
+# This makes binaries rebuild when SPIRE_VERSION changes, but NOT otherwise.
+$(VERSION_STAMP):
+	@mkdir -p $(BIN_DIR)
+	@echo "$(SPIRE_VERSION)" | cmp -s - $@ || echo "$(SPIRE_VERSION)" > $@
+
+# Download tarball for the specified version.
+$(TARBALL):
+	@mkdir -p $(BUILD_DIR)
+	@echo "==> Downloading SPIRE v$(SPIRE_VERSION)"
+	@$(DOWNLOADER) $@ "$(TARBALL_URL)"
+
+# Extract once and drop a fresh stamp so binaries depend only on this (not every file).
+$(EXTRACT_STAMP): $(TARBALL)
+	@echo "==> Extracting SPIRE v$(SPIRE_VERSION)"
+	@rm -rf "$(SRC_DIR)"
+	@tar -xzf "$(TARBALL)" -C "$(BUILD_DIR)"
+	@# Ensure the extracted directory matches expected name (GitHub tarball does).
+	@test -d "$(SRC_DIR)"
+	@touch "$(EXTRACT_STAMP)"
+
+# Build binaries (avoid rebuilds if up-to-date)
+$(SERVER_BIN): $(EXTRACT_STAMP) $(VERSION_STAMP)
+	@echo "==> Building $@ from SPIRE v$(SPIRE_VERSION)"
+	@cd "$(SRC_DIR)" && go build -o "$(abspath $@)" ./cmd/spire-server
+
+$(AGENT_BIN): $(EXTRACT_STAMP) $(VERSION_STAMP)
+	@echo "==> Building $@ from SPIRE v$(SPIRE_VERSION)"
+	@cd "$(SRC_DIR)" && go build -o "$(abspath $@)" ./cmd/spire-agent
+
+# Optional: quick sanity check that the built binaries run (prints version)
+verify: $(SERVER_BIN) $(AGENT_BIN)
+	@echo "==> Verifying binaries"
+	@$(SERVER_BIN) --version || { echo "ERROR: spire-server binary not ok"; }
+	@$(AGENT_BIN) --version  || { echo "ERROR: spire-agent binary not ok"; }
+
+# Clean built binaries only
+clean:
+	@echo "==> Cleaning binaries"
+	@rm -f "$(SERVER_BIN)" "$(AGENT_BIN)"
+	@rm -rf "$(BIN_DIR)"
+
+# Remove everything including downloads and extracted sources
+distclean: clean
+	@echo "==> Removing build artifacts"
+	@rm -rf "$(BUILD_DIR)" "$(VERSION_STAMP)"

--- a/spire/conf/agent.conf
+++ b/spire/conf/agent.conf
@@ -1,0 +1,56 @@
+{
+  "agent": [
+    {
+      "data_dir": "$TMPDIR/spire-agent/data",
+      "log_level": "DEBUG",
+      "server_address": "127.0.0.1",
+      "server_port": "8081",
+      "socket_path": "$TMPDIR/spire-agent/public/api.sock",
+      "trust_domain": "example.org",
+    }
+  ],
+  "health_checks": {
+    "bind_address": "0.0.0.0",
+    "bind_port": "8082",
+    "listener_enabled": true,
+    "live_path": "/live",
+    "ready_path": "/ready",
+  },
+  "plugins": [
+    {
+      "KeyManager": [
+        {
+          "memory": [
+            {
+              "plugin_data": [
+                {}
+              ]
+            }
+          ]
+        }
+      ],
+      "NodeAttestor": [
+        {
+          "join_token": [
+            {
+              "plugin_data": [
+                {}
+              ]
+            }
+          ]
+        }
+      ],
+      "WorkloadAttestor": [
+        {
+          "unix": [
+            {
+              "plugin_data": [
+                {}
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spire/conf/server.conf
+++ b/spire/conf/server.conf
@@ -1,0 +1,63 @@
+{
+  "server": [
+    {
+      "bind_address": "127.0.0.1",
+      "bind_port": "8081",
+      "ca_key_type": "rsa-2048",
+      "ca_ttl": "30m",
+      "data_dir": "$TMPDIR/spire-server/data",
+      "log_level": "DEBUG",
+      "socket_path": "$TMPDIR/spire-server/private/api.sock",
+      "trust_domain": "example.org"
+    }
+  ],
+  "health_checks": [
+    {
+      "bind_address": "0.0.0.0",
+      "bind_port": "8080",
+      "listener_enabled": true,
+      "live_path": "/live",
+      "ready_path": "/ready"
+    }
+  ],
+  "plugins": [
+    {
+      "DataStore": [
+        {
+          "sql": [
+            {
+              "plugin_data": [
+                {
+                  "connection_string": "$TMPDIR/spire-server/data/datastore.sqlite3",
+                  "database_type": "sqlite3"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "KeyManager": [
+        {
+          "memory": [
+            {
+              "plugin_data": [
+                {}
+              ]
+            }
+          ]
+        }
+      ],
+      "NodeAttestor": [
+        {
+          "join_token": [
+            {
+              "plugin_data": [
+                {}
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/client_stream.rs
+++ b/src/client_stream.rs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use rustls::{
+    ClientConfig, RootCertStore,
+    pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
+};
+use rustls_config_stream::{ClientConfigStreamBuilder, ClientConfigStreamError};
+use spiffe::{TrustDomain, WorkloadApiClient, X509BundleSet, X509Context, error::GrpcClientError};
+use tokio_stream::Stream;
+
+pub use rustls_config_stream::ClientConfigProvider;
+
+#[cfg(feature = "tracing")]
+use tracing::debug;
+
+/// Builder for a [`SpiffeClientConfigStream`] that provides [`rustls::ClientConfig`]
+/// objects built w/ trust bundles and workload X509-SVID from SPIFFE.
+///
+/// The builder controls which SPIFFE trust bundles are included in the
+/// internal [`rustls::RootCertStore`] used to build the [`ClientConfig`]
+pub struct SpiffeClientConfigStreamBuilder {
+    trust_domains: Vec<TrustDomain>,
+    client: Option<WorkloadApiClient>,
+}
+
+impl SpiffeClientConfigStreamBuilder {
+    /// Create a builder that can create [`SpiffeClientConfigStream`] objects
+    /// with the provided SPIFFE trust domains.
+    fn new(trust_domains: Vec<TrustDomain>) -> Self {
+        Self {
+            trust_domains,
+            client: None,
+        }
+    }
+}
+
+impl ClientConfigStreamBuilder for SpiffeClientConfigStreamBuilder {
+    type ConfigStream = SpiffeClientConfigStream;
+
+    async fn build(&mut self) -> Result<Self::ConfigStream, ClientConfigStreamError> {
+        let client = if let Some(client) = &mut self.client {
+            client
+        } else {
+            &mut WorkloadApiClient::default()
+                .await
+                .map_err(|e| ClientConfigStreamError::StreamBuilderError(e.into()))?
+        };
+        Ok(SpiffeClientConfigStream {
+            trust_domains: self.trust_domains.to_owned(),
+            inner: Pin::from(Box::from(
+                client
+                    .stream_x509_contexts()
+                    .await
+                    .map_err(|e| ClientConfigStreamError::StreamError(e.into()))?,
+            )),
+        })
+    }
+}
+
+/// A stream that yields updated [`rustls::ClientConfig`] values derived from the
+/// SPIFFE Workload API X509-SVID and Trust Bundles.
+///
+/// Each yielded config:
+/// * Uses the workload's default SVID (certificate chain + private key).
+/// * Requires (and verifies) server certificates whose trust anchors come from
+///   the configured SPIFFE trust domains.
+///
+/// # Behavior
+///
+/// * If the Workload API stream returns an error, this stream yields
+///   a [`ClientConfigStreamError::StreamError`] wrapping the original
+///   [`GrpcClientError`].
+/// * If an update lacks roots/SVID or the verifier cannot be built, the error
+///   is returned on the stream as a [`ClientConfigStreamError`]
+pub struct SpiffeClientConfigStream {
+    inner:
+        Pin<Box<dyn Stream<Item = Result<X509Context, GrpcClientError>> + Send + Sync + 'static>>,
+    trust_domains: Vec<TrustDomain>,
+}
+
+impl SpiffeClientConfigStream {
+    /// Create a builder that can create [`SpiffeClientConfigStream`] objects
+    /// with the provided SPIFFE trust domains.
+    pub fn builder(trust_domains: Vec<TrustDomain>) -> SpiffeClientConfigStreamBuilder {
+        SpiffeClientConfigStreamBuilder::new(trust_domains)
+    }
+
+    fn build_root_store(&self, bundles: &X509BundleSet) -> Arc<RootCertStore> {
+        let mut root_store = RootCertStore::empty();
+        let root_certs = self
+            .trust_domains
+            .iter()
+            .filter_map(|domain| bundles.get_bundle(domain))
+            .flat_map(|bundle| bundle.authorities())
+            .map(|authority| CertificateDer::from_slice(authority.content()));
+
+        let (added, ignored) = root_store.add_parsable_certificates(root_certs);
+
+        #[cfg(feature = "tracing")]
+        debug!(added, ignored);
+
+        Arc::new(root_store)
+    }
+
+    fn build_client_config(
+        &self,
+        x509_context: X509Context,
+    ) -> Result<Arc<ClientConfig>, ClientConfigStreamError> {
+        let roots = self.build_root_store(x509_context.bundle_set());
+        if roots.is_empty() {
+            return Err(ClientConfigStreamError::MissingRoots);
+        }
+        let svid = x509_context
+            .default_svid()
+            .ok_or(ClientConfigStreamError::MissingCertifiedKey)?;
+
+        #[cfg(feature = "tracing")]
+        debug!(workload_identity = %svid.spiffe_id());
+
+        let config = ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_client_auth_cert(
+                svid.cert_chain()
+                    .iter()
+                    .map(|c| CertificateDer::from(c.content().to_owned()))
+                    .collect(),
+                PrivateKeyDer::from(PrivatePkcs8KeyDer::from(
+                    svid.private_key().content().to_owned(),
+                )),
+            )
+            .map_err(|e| ClientConfigStreamError::RustlsError(e))?;
+        Ok(Arc::from(config))
+    }
+}
+
+impl Stream for SpiffeClientConfigStream {
+    type Item = Result<Arc<ClientConfig>, ClientConfigStreamError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.inner.as_mut().poll_next(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Ready(Some(Err(err))) => {
+                Poll::Ready(Some(Err(ClientConfigStreamError::StreamError(err.into()))))
+            }
+            Poll::Ready(Some(Ok(x509_context))) => match self.build_client_config(x509_context) {
+                Ok(config) => Poll::Ready(Some(Ok(config))),
+                Err(err) => Poll::Ready(Some(Err(err))),
+            },
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,23 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#![doc = include_str!("../README.md")]
+#![forbid(rust_2018_idioms)]
+#![forbid(missing_docs, unsafe_code)]
+#![deny(
+    clippy::all,
+    clippy::pedantic,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::nursery,
+    clippy::dbg_macro,
+    clippy::todo
+)]
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+#[cfg(feature = "config-stream")]
+mod client_stream;
+#[cfg(feature = "config-stream")]
+mod server_stream;
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+#[cfg(feature = "config-stream")]
+pub use client_stream::{ClientConfigProvider, SpiffeClientConfigStream};
+#[cfg(feature = "config-stream")]
+pub use server_stream::{ServerConfigProvider, SpiffeServerConfigStream};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-#![doc = include_str!("../README.md")]
+
+//! Dynamic [`rustls`] TLS configuration backed by [`rustls-spiffe`] and [`rustls-config-stream`].
+//! Effortlessly hot-swap new X509-SVIDs and Trust Bundles
+//!
+//! Provides [`SpiffeClientConfigStream`] and [`SpiffeServerConfigStream`] for
+//! use with [`ClientConfigProvider`] and [`ServerConfigProvider`]
+
 #![forbid(rust_2018_idioms)]
 #![forbid(missing_docs, unsafe_code)]
 #![deny(
@@ -21,3 +27,6 @@ mod server_stream;
 pub use client_stream::{ClientConfigProvider, SpiffeClientConfigStream};
 #[cfg(feature = "config-stream")]
 pub use server_stream::{ServerConfigProvider, SpiffeServerConfigStream};
+
+mod trust_domain_store;
+pub(crate) use trust_domain_store::TrustDomainStore;

--- a/src/server_stream.rs
+++ b/src/server_stream.rs
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use rustls::{
+    RootCertStore, ServerConfig,
+    pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
+    server::WebPkiClientVerifier,
+};
+use rustls_config_stream::{ServerConfigStreamBuilder, ServerConfigStreamError};
+use spiffe::{TrustDomain, WorkloadApiClient, X509BundleSet, X509Context, error::GrpcClientError};
+use tokio_stream::Stream;
+
+pub use rustls_config_stream::ServerConfigProvider;
+
+#[cfg(feature = "tracing")]
+use tracing::debug;
+
+/// Builder for a [`SpiffeServerConfigStream`] that provides [`rustls::ServerConfig`]
+/// objects built w/ trust bundles and workload X509-SVID from SPIFFE.
+///
+/// The builder controls which SPIFFE trust domains are allowed to authenticate
+/// clients.
+pub struct SpiffeServerConfigStreamBuilder {
+    trust_domains: Vec<TrustDomain>,
+    client: Option<WorkloadApiClient>,
+}
+
+impl SpiffeServerConfigStreamBuilder {
+    /// Create a builder that can create [`SpiffeServerConfigStream`] objects
+    /// with the provided SPIFFE trust domains.
+    fn new(trust_domains: Vec<TrustDomain>) -> Self {
+        Self {
+            trust_domains,
+            client: None,
+        }
+    }
+}
+impl ServerConfigStreamBuilder for SpiffeServerConfigStreamBuilder {
+    type ConfigStream = SpiffeServerConfigStream;
+
+    async fn build(&mut self) -> Result<Self::ConfigStream, ServerConfigStreamError> {
+        let client = if let Some(client) = &mut self.client {
+            client
+        } else {
+            &mut WorkloadApiClient::default()
+                .await
+                .map_err(|e| ServerConfigStreamError::StreamBuilderError(e.into()))?
+        };
+        Ok(SpiffeServerConfigStream {
+            trust_domains: self.trust_domains.to_owned(),
+            inner: Pin::from(Box::from(
+                client
+                    .stream_x509_contexts()
+                    .await
+                    .map_err(|e| ServerConfigStreamError::StreamError(e.into()))?,
+            )),
+        })
+    }
+}
+
+/// A stream that yields updated `rustls::ServerConfig` values derived from the
+/// SPIFFE Workload API X509-SVID and Trust Bundles.
+///
+/// Each yielded config:
+/// * Uses the workload's default SVID (certificate chain + private key).
+/// * Requires (and verifies) client certificates whose trust anchors come from
+///   the configured SPIFFE trust domains.
+///
+/// # Behavior
+///
+/// * If the Workload API stream returns an error, this stream yields
+///   a [`ServerConfigStreamError::StreamError`] wrapping the original
+///   [`GrpcClientError`].
+/// * If an update lacks roots/SVID or the verifier cannot be built, the error
+///   is returned on the stream as a [`ServerConfigStreamError`]
+///
+/// # Usage
+///
+/// ```rust
+/// use rustls_spiffe::{SpiffeServerConfigStream, ServerConfigProvider};
+/// use tracing::warn;
+///
+/// async fn run() {
+///     let config_stream_builder =
+///         SpiffeServerConfigStream::builder(vec!["example.org".try_into().unwrap()]);
+///     let config_provider = ServerConfigProvider::start(config_stream_builder)
+///         .await
+///         .unwrap();
+///     let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
+///         .await
+///         .unwrap();
+///     loop {
+///         let (stream, _) = listener.accept().await.unwrap();
+///
+///         let acceptor =
+///             tokio_rustls::LazyConfigAcceptor::new(rustls::server::Acceptor::default(), stream);
+///         tokio::pin!(acceptor);
+///
+///         let config_provider = config_provider.clone();
+///         match acceptor.as_mut().await {
+///             Ok(start) => {
+///                 tokio::spawn(async move {
+///                     if !config_provider.stream_healthy() {
+///                         warn!(
+///                             "config provider does not have healthy stream; TLS config may be out of date"
+///                         );
+///                     }
+///                     let config = config_provider.get_config();
+///                     match start.into_stream(config).await {
+///                         Ok(stream) => {
+///                             // serve some app (e.g. hyper, tower, axum)
+///                             todo!();
+///                         }
+///                         Err(err) => {
+///                             // add error handling as-desired
+///                             todo!()
+///                         },
+///                     }
+///                 });
+///             }
+///             Err(err) => {
+///                 // add error-handling as-desired
+///                 todo!()
+///             },
+///         }
+///     }
+/// }
+/// ```
+
+pub struct SpiffeServerConfigStream {
+    inner:
+        Pin<Box<dyn Stream<Item = Result<X509Context, GrpcClientError>> + Send + Sync + 'static>>,
+    trust_domains: Vec<TrustDomain>,
+}
+
+impl SpiffeServerConfigStream {
+    /// Create a builder that can create [`SpiffeServerConfigStream`] objects
+    /// with the provided SPIFFE trust domains.
+    pub fn builder(trust_domains: Vec<TrustDomain>) -> SpiffeServerConfigStreamBuilder {
+        SpiffeServerConfigStreamBuilder::new(trust_domains)
+    }
+
+    fn build_root_store(&self, bundles: &X509BundleSet) -> Arc<RootCertStore> {
+        let mut root_store = RootCertStore::empty();
+        let root_certs = self
+            .trust_domains
+            .iter()
+            .filter_map(|domain| bundles.get_bundle(domain))
+            .flat_map(|bundle| bundle.authorities())
+            .map(|authority| CertificateDer::from_slice(authority.content()));
+
+        let (added, ignored) = root_store.add_parsable_certificates(root_certs);
+
+        #[cfg(feature = "tracing")]
+        debug!(added, ignored);
+
+        Arc::new(root_store)
+    }
+
+    fn build_server_config(
+        &self,
+        x509_context: X509Context,
+    ) -> Result<Arc<ServerConfig>, ServerConfigStreamError> {
+        let roots = self.build_root_store(x509_context.bundle_set());
+        if roots.is_empty() {
+            return Err(ServerConfigStreamError::MissingRoots);
+        }
+        let verifier = WebPkiClientVerifier::builder(roots)
+            .build()
+            .map_err(|e| ServerConfigStreamError::VerifierBuilderError(e))?;
+        let svid = x509_context
+            .default_svid()
+            .ok_or(ServerConfigStreamError::MissingCertifiedKey)?;
+
+        #[cfg(feature = "tracing")]
+        debug!(workload_identity = %svid.spiffe_id());
+
+        let config = ServerConfig::builder()
+            .with_client_cert_verifier(verifier)
+            .with_single_cert(
+                svid.cert_chain()
+                    .iter()
+                    .map(|c| CertificateDer::from(c.content().to_owned()))
+                    .collect(),
+                PrivateKeyDer::from(PrivatePkcs8KeyDer::from(
+                    svid.private_key().content().to_owned(),
+                )),
+            )
+            .map_err(|e| ServerConfigStreamError::RustlsError(e))?;
+        Ok(Arc::from(config))
+    }
+}
+
+impl Stream for SpiffeServerConfigStream {
+    type Item = Result<Arc<ServerConfig>, ServerConfigStreamError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.inner.as_mut().poll_next(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Ready(Some(Err(err))) => {
+                Poll::Ready(Some(Err(ServerConfigStreamError::StreamError(err.into()))))
+            }
+            Poll::Ready(Some(Ok(x509_context))) => match self.build_server_config(x509_context) {
+                Ok(config) => Poll::Ready(Some(Ok(config))),
+                Err(err) => Poll::Ready(Some(Err(err))),
+            },
+        }
+    }
+}

--- a/src/trust_domain_store.rs
+++ b/src/trust_domain_store.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+use rustls::{RootCertStore, pki_types::CertificateDer};
+use spiffe::{TrustDomain, X509Bundle, X509BundleSet};
+use std::sync::Arc;
+#[cfg(feature = "tracing")]
+use tracing::debug;
+
+pub trait TrustDomainStore {
+    fn get_trust_domains(&self) -> &Vec<TrustDomain>;
+    fn build_root_store(&self, bundles: &X509BundleSet) -> Arc<RootCertStore> {
+        let mut root_store = RootCertStore::empty();
+        let root_certs = self
+            .get_trust_domains()
+            .iter()
+            .filter_map(|domain| bundles.get_bundle(domain))
+            .flat_map(X509Bundle::authorities)
+            .map(|authority| CertificateDer::from_slice(authority.content()));
+
+        let (added, ignored) = root_store.add_parsable_certificates(root_certs);
+
+        #[cfg(feature = "tracing")]
+        debug!(added, ignored);
+
+        Arc::new(root_store)
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -12,16 +12,17 @@ use tokio_rustls::server::TlsStream;
 use x509_parser::prelude::GeneralName;
 
 #[inline(always)]
-pub(crate) fn extract_leaf_cert(stream: &TlsStream<TcpStream>) -> Option<&CertificateDer> {
+pub(crate) fn extract_leaf_cert<'a>(
+    stream: &'a TlsStream<TcpStream>,
+) -> Option<&'a CertificateDer<'a>> {
     let (_, state) = stream.get_ref();
-    let peer_certificates = state.peer_certificates();
-    let chain = peer_certificates?;
-    let leaf = chain.first()?;
+    let peer_certificates = state.peer_certificates()?;
+    let leaf = peer_certificates.first()?;
     Some(leaf)
 }
 
 #[inline(always)]
-pub(crate) fn extract_spiffe_id(leaf: Option<&CertificateDer>) -> Option<SpiffeId> {
+pub(crate) fn extract_spiffe_id<'a>(leaf: Option<&'a CertificateDer>) -> Option<SpiffeId> {
     let leaf = leaf?;
     let (_, cert) = x509_parser::parse_x509_certificate(leaf).ok()?;
     let san = cert.subject_alternative_name().ok()??;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,117 @@
+use rustls_spiffe::{
+    ClientConfigProvider, ServerConfigProvider, SpiffeClientConfigStream, SpiffeServerConfigStream,
+};
+
+use rustls::pki_types::CertificateDer;
+use spiffe::SpiffeId;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpStream,
+};
+use tokio_rustls::server::TlsStream;
+use x509_parser::prelude::GeneralName;
+
+#[inline(always)]
+pub(crate) fn extract_leaf_cert(stream: &TlsStream<TcpStream>) -> Option<&CertificateDer> {
+    let (_, state) = stream.get_ref();
+    let peer_certificates = state.peer_certificates();
+    let chain = peer_certificates?;
+    let leaf = chain.first()?;
+    Some(leaf)
+}
+
+#[inline(always)]
+pub(crate) fn extract_spiffe_id(leaf: Option<&CertificateDer>) -> Option<SpiffeId> {
+    let leaf = leaf?;
+    let (_, cert) = x509_parser::parse_x509_certificate(leaf).ok()?;
+    let san = cert.subject_alternative_name().ok()??;
+    let uri = san.value.general_names.iter().find_map(|gn| match gn {
+        GeneralName::URI(uri) => Some(*uri),
+        _ => None,
+    })?;
+    SpiffeId::try_from(uri).ok()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn successful_handshake() {
+    rustls::crypto::CryptoProvider::install_default(rustls::crypto::aws_lc_rs::default_provider())
+        .unwrap();
+    let (req, res) = tokio::join!(oneshot_server(), client());
+    let res = res.unwrap();
+    let req = req.unwrap();
+    assert_eq!(req.data, "PING",);
+    assert_eq!(
+        req.svid,
+        "spiffe://example.org/testservice".try_into().unwrap()
+    );
+    assert_eq!(res, "PONG",);
+}
+
+struct Request {
+    data: String,
+    svid: SpiffeId,
+}
+
+async fn oneshot_server() -> Result<Request, Box<dyn std::error::Error>> {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
+        .await
+        .unwrap();
+    let config_stream_builder =
+        SpiffeServerConfigStream::builder(vec!["example.org".try_into().unwrap()]);
+    let config_provider = ServerConfigProvider::start(config_stream_builder)
+        .await
+        .unwrap();
+
+    let (stream, _) = listener.accept().await.unwrap();
+
+    let acceptor =
+        tokio_rustls::LazyConfigAcceptor::new(rustls::server::Acceptor::default(), stream);
+    tokio::pin!(acceptor);
+
+    let config_provider = config_provider.clone();
+    match acceptor.as_mut().await {
+        Ok(start) => {
+            let config = config_provider.get_config();
+            let mut stream = start.into_stream(config).await.unwrap();
+            let leaf = extract_leaf_cert(&stream);
+            let svid = extract_spiffe_id(leaf).unwrap();
+            let mut buf = Vec::new();
+            stream.read_to_end(&mut buf).await.unwrap();
+            stream.write_all("PONG".as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+            Ok(Request {
+                data: String::from_utf8_lossy(&buf).to_string(),
+                svid,
+            })
+        }
+        Err(err) => {
+            if let Some(mut stream) = acceptor.take_io() {
+                stream.write_all("FAIL".as_bytes()).await.unwrap();
+            }
+            Err(err.into())
+        }
+    }
+}
+
+async fn client() -> Result<String, Box<dyn std::error::Error>> {
+    let stream = tokio::net::TcpStream::connect("127.0.0.1:3000")
+        .await
+        .unwrap();
+    let config_provider = ClientConfigProvider::start(SpiffeClientConfigStream::builder(vec![
+        "example.org".try_into().unwrap(),
+    ]))
+    .await
+    .unwrap();
+    let connector = tokio_rustls::TlsConnector::from(config_provider.get_config());
+    let tstream = connector
+        .connect("localhost".try_into().unwrap(), stream)
+        .await
+        .unwrap();
+    let (mut rx, mut tx) = tokio::io::split(tstream);
+    tx.write_all("PING".as_bytes()).await.unwrap();
+    tx.shutdown().await.unwrap();
+    let mut buf = Vec::new();
+    rx.read_to_end(&mut buf).await.unwrap();
+    let res = String::from_utf8_lossy(&buf).to_string();
+    Ok(res)
+}


### PR DESCRIPTION
- Add `rustls_spiffe::ClientConfigStreamBuilder` to provide a SPIFFE X509-SVID backed `rustls::ClientConfig` stream for `rustls_config_stream::ClientConfigProvider` usage
- Add `rustls_spiffe::ServerConfigStreamBuilder` to provide a SPIFFE X509-SVID backed `rustls::ServerConfig` stream for `rustls_config_stream::ServerConfigProvider` usage