### PR TITLE
feat: add `svid-extractor`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,21 +12,22 @@ rustls = { version = "0.23.31", default-features = false, features = [
 ] }
 rustls-config-stream = { version = "0.2.0", default-features = false, optional = true }
 spiffe = "0.6.7"
+tokio = { version = "1.47.1", default-features = false, optional = true }
 tokio-stream = { version = "0.1.17", default-features = false, optional = true }
 tracing = { version = "0.1.41", default-features = false, optional = true }
 x509-parser = { version = "0.18.0", optional = true }
+tokio-rustls = { version = "0.26.3", optional = true }
 
 [features]
 default = ["full"]
 full = ["config-stream", "svid-extractor", "tracing"]
 tracing = ["dep:tracing", "rustls-config-stream?/tracing"]
 config-stream = ["dep:rustls-config-stream", "dep:tokio-stream"]
-svid-extractor = ["dep:x509-parser"]
+svid-extractor = ["dep:x509-parser", "dep:tokio", "dep:tokio-rustls"]
 
 [dev-dependencies]
 axum = "0.8.4"
 hyper = "1.7.0"
 hyper-util = "0.1.17"
 tokio = { version = "1.47.1", features = ["rt-multi-thread"] }
-tokio-rustls = "0.26.3"
 tower-service = "0.3.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,11 +22,19 @@
 mod client_stream;
 #[cfg(feature = "config-stream")]
 mod server_stream;
+#[cfg(feature = "svid-extractor")]
+mod svid_extractor;
 
 #[cfg(feature = "config-stream")]
+#[cfg_attr(docsrs, doc(cfg(feature = "config-stream")))]
 pub use client_stream::{ClientConfigProvider, SpiffeClientConfigStream};
 #[cfg(feature = "config-stream")]
+#[cfg_attr(docsrs, doc(cfg(feature = "config-stream")))]
 pub use server_stream::{ServerConfigProvider, SpiffeServerConfigStream};
 
 mod trust_domain_store;
 pub(crate) use trust_domain_store::TrustDomainStore;
+
+#[cfg(feature = "svid-extractor")]
+#[cfg_attr(docsrs, doc(cfg(feature = "svid-extractor")))]
+pub use svid_extractor::{extract_leaf_cert, extract_spiffe_id};

--- a/src/svid_extractor.rs
+++ b/src/svid_extractor.rs
@@ -1,0 +1,29 @@
+use rustls::pki_types::CertificateDer;
+use spiffe::SpiffeId;
+use tokio::net::TcpStream;
+use tokio_rustls::server::TlsStream;
+use x509_parser::prelude::GeneralName;
+
+/// Extract the leaf [`CertificateDer`] from a [`TlsStream`]
+#[inline]
+#[must_use]
+pub fn extract_leaf_cert(stream: &TlsStream<TcpStream>) -> Option<&CertificateDer<'_>> {
+    let (_, state) = stream.get_ref();
+    let peer_certificates = state.peer_certificates()?;
+    let leaf = peer_certificates.first()?;
+    Some(leaf)
+}
+
+/// Extract a [`SpiffeId`] from a [`CertificateDer`] if the certificate is a valid X509-SVID
+#[inline]
+#[must_use]
+pub fn extract_spiffe_id(leaf: Option<&CertificateDer<'_>>) -> Option<SpiffeId> {
+    let leaf = leaf?;
+    let (_, cert) = x509_parser::parse_x509_certificate(leaf).ok()?;
+    let san = cert.subject_alternative_name().ok()??;
+    let uri = san.value.general_names.iter().find_map(|gn| match gn {
+        GeneralName::URI(uri) => Some(*uri),
+        _ => None,
+    })?;
+    SpiffeId::try_from(uri).ok()
+}


### PR DESCRIPTION
Move `extract_leaf_certificate` and `extract_spiffe_id` from integration tests to lib under `svid-extractor` feature.